### PR TITLE
Remove duplicate CI trigger

### DIFF
--- a/.github/workflows/reindex.yaml
+++ b/.github/workflows/reindex.yaml
@@ -3,9 +3,6 @@ name: Reindex
 on:
   release:
     types: [released]
-  workflow_run:
-    workflows: ["Release"]
-    types: [completed]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Get rid of two CI jobs for the same release:

<img width="1497" height="794" alt="image" src="https://github.com/user-attachments/assets/efe2cdd7-0aad-4615-8b6b-475cdebd7787" />
