### PR TITLE
Beyla memory management

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: collector
 description: A Helm chart for Better Stack Collector - monitoring solution that collects metrics, logs, and traces
 type: application
-version: 0.1.9
+version: 0.1.10
 appVersion: "latest"
 keywords:
   - monitoring

--- a/README.md
+++ b/README.md
@@ -12,6 +12,23 @@ Better Stack collector is the easiest and recommended way of integrating Better 
 
 [Getting started ⇗](https://betterstack.com/docs/logs/collector/#getting-started)
 
+## System Requirements
+
+### Memory Requirements
+
+The Better Stack collector runs as a DaemonSet with two containers per node:
+- **Collector container**: 512MB-2GB memory
+- **Beyla container** (eBPF tracing): 1.5GB memory reserved
+
+**Minimum recommended node specifications:**
+- 4GB total memory per node
+- 2GB available memory after system and other critical workloads
+
+**Important notes:**
+- The Beyla container requires 1.5GB memory reservation to ensure stable eBPF-based tracing
+- In memory-constrained or heavily overcommitted clusters, the collector may experience restarts
+- Both containers are configured with Guaranteed QoS class to prevent eviction under memory pressure
+
 ## Need help?
 
 Please let us know at [hello@betterstack.com](mailto:hello@betterstack.com). We're happy to help!

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -142,6 +142,26 @@ spec:
           value: /etc/beyla/beyla.yaml
         - name: ENABLE_DOCKERPROBE
           value: {{ .Values.beyla.dockerprobe.enabled | quote }}
+        {{- if .Values.beyla.memoryRestartThreshold }}
+        livenessProbe:
+          exec:
+            command:
+            - /bin/sh
+            - -c
+            - |
+              # Get memory usage in MiB
+              MEM_USAGE=$(cat /proc/1/status | grep VmRSS | awk '{print int($2/1024)}')
+              THRESHOLD={{ .Values.beyla.memoryRestartThreshold }}
+              if [ "$MEM_USAGE" -gt "$THRESHOLD" ]; then
+                echo "Memory usage ${MEM_USAGE}MiB exceeds threshold ${THRESHOLD}MiB"
+                exit 1
+              fi
+              exit 0
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 5
+          failureThreshold: 2
+        {{- end }}
         volumeMounts:
         {{- if .Values.beyla.dockerprobe.enabled }}
         - name: docker-metadata

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -142,6 +142,8 @@ spec:
           value: /etc/beyla/beyla.yaml
         - name: ENABLE_DOCKERPROBE
           value: {{ .Values.beyla.dockerprobe.enabled | quote }}
+        - name: GOMEMLIMIT
+          value: {{ .Values.beyla.env.GOMEMLIMIT | quote }}
         {{- if .Values.beyla.memoryRestartThreshold }}
         livenessProbe:
           exec:

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -149,11 +149,15 @@ spec:
             - /bin/sh
             - -c
             - |
-              # Get memory usage in MiB
-              MEM_USAGE=$(cat /proc/1/status | grep VmRSS | awk '{print int($2/1024)}')
+              BEYLA_PID=$(pgrep -f '^/usr/local/bin/beyla' | head -1)
+              if [ -z "$BEYLA_PID" ]; then
+                echo "Beyla process not found"
+                exit 1
+              fi
+              MEM_USAGE=$(cat /proc/$BEYLA_PID/status | grep VmRSS | awk '{print int($2/1024)}')
               THRESHOLD={{ .Values.beyla.memoryRestartThreshold }}
               if [ "$MEM_USAGE" -gt "$THRESHOLD" ]; then
-                echo "Memory usage ${MEM_USAGE}MiB exceeds threshold ${THRESHOLD}MiB"
+                echo "Beyla memory usage ${MEM_USAGE}MiB exceeds threshold ${THRESHOLD}MiB"
                 exit 1
               fi
               exit 0

--- a/values.yaml
+++ b/values.yaml
@@ -79,7 +79,7 @@ beyla:
   # Memory restart threshold in MiB (optional)
   # If set, beyla will restart when memory usage exceeds this value
   # Should be set below the memory limit to prevent OOM kills
-  memoryRestartThreshold: 1400
+  memoryRestartThreshold: 1450
 
 # RBAC configuration
 rbac:

--- a/values.yaml
+++ b/values.yaml
@@ -75,6 +75,11 @@ beyla:
       cpu: 250m
       memory: 1536Mi
 
+  # Memory restart threshold in MiB (optional)
+  # If set, beyla will restart when memory usage exceeds this value
+  # Should be set below the memory limit to prevent OOM kills
+  memoryRestartThreshold: 1400
+
 # RBAC configuration
 rbac:
   # Create service account

--- a/values.yaml
+++ b/values.yaml
@@ -61,6 +61,7 @@ beyla:
     BEYLA_KUBE_METADATA_ENABLE: "true"
     BEYLA_METRICS_INTERVAL: "15s"
     BEYLA_NETWORK_METRICS: "false"
+    GOMEMLIMIT: 1400MiB
 
   # Docker probe configuration
   dockerprobe:

--- a/values.yaml
+++ b/values.yaml
@@ -73,7 +73,7 @@ beyla:
       memory: 1536Mi
     requests:
       cpu: 250m
-      memory: 512Mi
+      memory: 1536Mi
 
 # RBAC configuration
 rbac:

--- a/values.yaml
+++ b/values.yaml
@@ -22,8 +22,8 @@ collector:
       cpu: 2000m
       memory: 2Gi
     requests:
-      cpu: 500m
-      memory: 512Mi
+      cpu: 2000m
+      memory: 2Gi
 
   # Node selector
   nodeSelector: {}
@@ -72,7 +72,7 @@ beyla:
       cpu: 1000m
       memory: 1536Mi
     requests:
-      cpu: 250m
+      cpu: 1000m
       memory: 1536Mi
 
   # Memory restart threshold in MiB (optional)


### PR DESCRIPTION
- added request memory equal to limit
- a sprinkling of docs - if they are better suited to the official documentation page, let me know 🙏 
- a speculative feature to restart the container at ~1300Mi
  - idea being, it's better that beyla sigterms cleanly (flushing buffers) than get oomkilled

Let me know what you think!