### PR TITLE
limit collector container resource requests

### DIFF
--- a/.github/workflows/reindex.yaml
+++ b/.github/workflows/reindex.yaml
@@ -4,6 +4,7 @@ on:
   release:
     types: [released]
   workflow_dispatch:
+  workflow_call:
 
 permissions:
   id-token: write

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,6 +7,8 @@ on:
 
 permissions:
   contents: write
+  id-token: write
+  pages: write
 
 jobs:
   release:
@@ -26,3 +28,7 @@ jobs:
         uses: softprops/action-gh-release@v2.3.2
         with:
           files: '*.tgz'
+  
+  reindex:
+    needs: release
+    uses: ./.github/workflows/reindex.yaml

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: collector
 description: A Helm chart for Better Stack Collector - monitoring solution that collects metrics, logs, and traces
 type: application
-version: 0.1.10
+version: 0.1.11
 appVersion: "latest"
 keywords:
   - monitoring

--- a/values.yaml
+++ b/values.yaml
@@ -22,7 +22,7 @@ collector:
       cpu: 2000m
       memory: 2Gi
     requests:
-      cpu: 2000m
+      cpu: 500m
       memory: 2Gi
 
   # Node selector
@@ -73,7 +73,7 @@ beyla:
       cpu: 1000m
       memory: 1536Mi
     requests:
-      cpu: 1000m
+      cpu: 500m
       memory: 1536Mi
 
   # Memory restart threshold in MiB (optional)

--- a/values.yaml
+++ b/values.yaml
@@ -23,7 +23,7 @@ collector:
       memory: 2Gi
     requests:
       cpu: 500m
-      memory: 2Gi
+      memory: 512Mi
 
   # Node selector
   nodeSelector: {}


### PR DESCRIPTION
- we haven't seen specific memory/cpu issues from that container
- it'll help us fit on smaller nodes

also attempts to call the reindex action after release