### PR TITLE
Add read-only host filesystem mount for Vector

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: collector
 description: A Helm chart for Better Stack Collector - monitoring solution that collects metrics, logs, and traces
 type: application
-version: 0.1.11
+version: 0.1.12
 appVersion: "latest"
 keywords:
   - monitoring

--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -76,23 +76,14 @@ spec:
         - name: cgroup
           mountPath: /sys/fs/cgroup
           readOnly: true
-        - name: hostname
-          mountPath: /host/proc/sys/kernel/hostname
-          readOnly: true
-        - name: varlog
-          mountPath: /host/var/log
-          readOnly: true
         - name: varlog-pods
           mountPath: /var/log/pods
           readOnly: true
         - name: docker-containers
           mountPath: /var/lib/docker/containers
           readOnly: true
-        - name: procfs
-          mountPath: /host/proc
-          readOnly: true
-        - name: sysfs
-          mountPath: /host/sys
+        - name: hostfs
+          mountPath: /host
           readOnly: true
         resources:
           {{- toYaml .Values.collector.resources | nindent 10 }}
@@ -193,25 +184,15 @@ spec:
       - name: cgroup
         hostPath:
           path: /sys/fs/cgroup
-      - name: hostname
-        hostPath:
-          path: /proc/sys/kernel/hostname
-      - name: varlog
-        hostPath:
-          path: /var/log
       - name: varlog-pods
         hostPath:
           path: /var/log/pods
       - name: docker-containers
         hostPath:
           path: /var/lib/docker/containers
-      - name: procfs
+      - name: hostfs
         hostPath:
-          path: /proc
-          type: ""
-      - name: sysfs
-        hostPath:
-          path: /sys
+          path: /
           type: ""
       {{- if .Values.beyla.enabled }}
       # Beyla volumes


### PR DESCRIPTION
Mount `/:/host:ro` to allow reading custom log files with manual Vector config, e.g. from `/var/www`.