### PR TITLE
Add digest option to images

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -35,8 +35,14 @@ spec:
       containers:
       # Collector container (non-privileged)
       - name: collector
-        image: "{{ .Values.collector.image.repository }}:{{ .Values.collector.image.tag | default .Chart.AppVersion }}"
-        imagePullPolicy: {{ .Values.collector.image.pullPolicy }}
+        {{- with .Values.collector.image }}
+        {{- if .digest }}
+        image: "{{ .repository }}@{{ .digest }}"
+        {{- else }}
+        image: "{{ .repository }}:{{ .tag | default $.Chart.AppVersion }}"
+        {{- end }}
+        imagePullPolicy: {{ .pullPolicy }}
+        {{- end }}
         securityContext:
           runAsNonRoot: false
           runAsUser: 0
@@ -141,8 +147,14 @@ spec:
       {{- if eq (include "better-stack-collector.ebpf.enabled" .) "true" }}
       {{- $ebpf := include "better-stack-collector.ebpf" . | fromYaml }}
       - name: ebpf
-        image: "{{ $ebpf.image.repository }}:{{ $ebpf.image.tag }}"
-        imagePullPolicy: {{ $ebpf.image.pullPolicy }}
+        {{- with $ebpf.image }}
+        {{- if .digest }}
+        image: "{{ .repository }}@{{ .digest }}"
+        {{- else }}
+        image: "{{ .repository }}:{{ .tag }}"
+        {{- end }}
+        imagePullPolicy: {{ .pullPolicy }}
+        {{- end }}
         securityContext:
           {{- include "better-stack-collector.ebpf.securityContext" . | nindent 10 }}
         env:

--- a/values.yaml
+++ b/values.yaml
@@ -7,6 +7,7 @@ collector:
   image:
     repository: ghcr.io/betterstackhq/collector
     tag: latest
+    digest: ""
     pullPolicy: Always
 
   # Environment variables
@@ -69,6 +70,7 @@ ebpf:
   image:
     repository: ghcr.io/betterstackhq/collector-ebpf
     tag: latest
+    digest: ""
     pullPolicy: Always
 
   env:


### PR DESCRIPTION
Passing a digest is a more stable way, although not as pretty, way to designate the image version to run. Since tags can be replaced with new images, passing a digest enforces the specific image does not change snce a new push to a tag would have a new digest. However, specifying the digest uses the [at] symbol as a separator instead of a colon. This allows passing a digest of the form `sha256:awesomedigest...`, falling back to passing a normal tag when a digest is not given.