### PR TITLE
feat: expose collector.updateStrategy for the DaemonSet

### DIFF
--- a/templates/daemonset.yaml
+++ b/templates/daemonset.yaml
@@ -7,6 +7,10 @@ metadata:
     {{- include "better-stack-collector.labels" . | nindent 4 }}
     app.kubernetes.io/component: better-stack-collector
 spec:
+  {{- with .Values.collector.updateStrategy }}
+  updateStrategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "better-stack-collector.selectorLabels" . | nindent 6 }}

--- a/tests/17-update-strategy.sh
+++ b/tests/17-update-strategy.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+output=$(render \
+  --set collector.env.COLLECTOR_SECRET=test123 \
+  --set 'collector.updateStrategy.type=RollingUpdate' \
+  --set 'collector.updateStrategy.rollingUpdate.maxUnavailable=25%' \
+  --set 'collector.updateStrategy.rollingUpdate.maxSurge=0')
+
+assert_contains "$output" 'updateStrategy:' "Missing updateStrategy block on DaemonSet"
+assert_contains "$output" 'type: RollingUpdate' "Missing updateStrategy.type"
+assert_contains "$output" 'maxUnavailable: 25%' "Missing maxUnavailable override"
+assert_contains "$output" 'maxSurge: 0' "Missing maxSurge override"
+
+pass

--- a/tests/18-no-update-strategy.sh
+++ b/tests/18-no-update-strategy.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+source "$(dirname "$0")/helpers.sh"
+
+# Default values must not emit an updateStrategy block, so Kubernetes
+# applies its DaemonSet default and existing installs see no change.
+output=$(render --set collector.env.COLLECTOR_SECRET=test123)
+
+assert_not_contains "$output" 'updateStrategy:' \
+  "Unexpected updateStrategy block when collector.updateStrategy is unset"
+
+pass

--- a/values.yaml
+++ b/values.yaml
@@ -44,6 +44,20 @@ collector:
   # Affinity
   affinity: {}
 
+  # DaemonSet update strategy. When left empty, Kubernetes applies its default
+  # for DaemonSets — RollingUpdate with maxUnavailable: 1 and maxSurge: 0 —
+  # which rolls one pod at a time and serializes the rollout on large clusters
+  # (e.g. ~15 min for 15 nodes, ~30 min for 32 nodes). Override to roll more
+  # pods concurrently; a percentage scales naturally with cluster size.
+  # See https://kubernetes.io/docs/concepts/workloads/controllers/daemonset/#rolling-update
+  updateStrategy: {}
+  # Example:
+  # updateStrategy:
+  #   type: RollingUpdate
+  #   rollingUpdate:
+  #     maxUnavailable: 25%
+  #     maxSurge: 0
+
   livenessProbe:
     initialDelaySeconds: 180
     periodSeconds: 60


### PR DESCRIPTION
> I'm sure it's not hard to tell this is a vibe coded PR. I had tried to update a configuration in my betterstack collector using the helm chart, and found myself waiting 30 minutes for it to go through. Claude claimed the update had happened one pod at a time. I wanted to expose `maxUnavailable` and `maxSurge` so I could tune that for our clusters where we've got plenty of nodes and a little downtime in the collector layer (worst case) is not high stakes.

---

## What

Adds a new `collector.updateStrategy` value that maps directly onto the DaemonSet `spec.updateStrategy`. Defaults to an empty object so Kubernetes applies its standard DaemonSet update strategy — existing installs see **no behavior change**.

## Why

On a fresh `helm upgrade` of v0.1.42 against a 15-node Kubernetes cluster, the collector DaemonSet took **~15 minutes** to fully roll out; on a 32-node cluster it stretched past **30 minutes**. The cause is the Kubernetes DaemonSet default of `maxUnavailable: 1, maxSurge: 0` (see [k8s docs — Performing a Rolling Update on a DaemonSet](https://kubernetes.io/docs/tasks/manage-daemon/update-daemon-set/)) — only one collector pod is replaced at a time.

The chart does not currently expose any way to override this — there is no `updateStrategy` in `values.yaml` and no `spec.updateStrategy` block in `templates/daemonset.yaml`. The only workarounds today are a post-install `kubectl patch` (gets reverted on the next `helm upgrade`), a fork, or a `helm --post-renderer` kustomize hack.

We hit this in our environment while iterating on a related change (enabling `collectOtel.grpcPort` / `httpPort` and waiting for the rollout to reach the node hosting an OTLP-emitting workload). Because the collector is a telemetry sidecar — not on the critical request path — operators typically want to roll many pods in parallel.

## Usage

```yaml
collector:
  updateStrategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 25%
      maxSurge: 0
```

A 25% setting cuts a 15-node rollout to ~4 pods at a time and a 32-node rollout to ~8 at a time. Operators who want the previous behavior simply leave the field unset.

## Changes

- `values.yaml` — new `collector.updateStrategy` key (default `{}`) with a comment explaining the trade-off and a commented-out example.
- `templates/daemonset.yaml` — wraps the new field in `{{- with .Values.collector.updateStrategy }} ... {{- end }}` so the block is only emitted when explicitly set. Existing installs render byte-identical YAML.
- `tests/17-update-strategy.sh` — verifies an override flows through to the rendered DaemonSet (`updateStrategy.type`, `maxUnavailable`, `maxSurge`).
- `tests/18-no-update-strategy.sh` — verifies the default render emits **no** `updateStrategy` block, guarding against accidental behavior change for current users.

All 18 chart tests pass locally.

## Backward compatibility

100% compatible — default behavior is identical (no `updateStrategy` rendered, Kubernetes uses its DaemonSet default).